### PR TITLE
fix(storage): return undefined not null when get tokens

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="e8cd04de-59fb-497c-b478-dc83083e253f" name="Default Changelist" comment="chore: fix branch name">
+    <list default="true" id="e8cd04de-59fb-497c-b478-dc83083e253f" name="Default Changelist" comment="chore: fix branch name on semantic release">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/index.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/index.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -30,6 +30,7 @@
     </file-type-list>
   </component>
   <component name="GitToolBoxStore">
+    <option name="projectConfigVersion" value="5" />
     <option name="recentBranches">
       <RecentBranches>
         <option name="branchesForRepo">
@@ -224,7 +225,8 @@
       <workItem from="1648303938442" duration="18647000" />
       <workItem from="1648524972884" duration="24494000" />
       <workItem from="1649105644392" duration="722000" />
-      <workItem from="1649107498906" duration="39640000" />
+      <workItem from="1649107498906" duration="40359000" />
+      <workItem from="1649344354475" duration="340000" />
     </task>
     <task id="LOCAL-00001" summary="NEW:v3.0.0">
       <created>1614872764649</created>
@@ -373,7 +375,14 @@
       <option name="project" value="LOCAL" />
       <updated>1649306000267</updated>
     </task>
-    <option name="localTasksCounter" value="22" />
+    <task id="LOCAL-00022" summary="chore: fix branch name on semantic release">
+      <created>1649306376163</created>
+      <option name="number" value="00022" />
+      <option name="presentableId" value="LOCAL-00022" />
+      <option name="project" value="LOCAL" />
+      <updated>1649306376163</updated>
+    </task>
+    <option name="localTasksCounter" value="23" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -407,7 +416,8 @@
     <MESSAGE value="chore: remove node-fetch not need anymore" />
     <MESSAGE value="fix: remove unnecessary expired conditional" />
     <MESSAGE value="chore: fix branch name" />
-    <option name="LAST_COMMIT_MESSAGE" value="chore: fix branch name" />
+    <MESSAGE value="chore: fix branch name on semantic release" />
+    <option name="LAST_COMMIT_MESSAGE" value="chore: fix branch name on semantic release" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
     <SUITE FILE_PATH="coverage/front_auth_handler$test_web_auth_test_js.dat" NAME="test/web-auth.test.js Coverage Results" MODIFIED="1614825109024" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="MochaJavaScriptTestRunnerCoverage" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" />

--- a/src/index.js
+++ b/src/index.js
@@ -160,8 +160,8 @@ class WebAuth {
      */
     getTokens(token) {
         const tokens = {
-            accessToken: window[this.storage].getItem(this.keys.accessToken),
-            refreshToken: window[this.storage].getItem(this.keys.refreshToken)
+            accessToken: window[this.storage].getItem(this.keys.accessToken) || undefined,
+            refreshToken: window[this.storage].getItem(this.keys.refreshToken) || undefined
         };
         this.debug('log', `Getting token from ${this.storage}`, tokens);
         return token ? tokens[token] : tokens;


### PR DESCRIPTION
By default, storage returns `null` instead of `undefined` when `getItem(...)` is invoked. In the test, it is using storage polyfill as an object store, so if the key does not exists returns `undefined`.

```js
const output = localStorage.getItem('not-defined-key') || sessionStorage.getItem('not-defined-key');
console.log(output);
// null
```

This provokes when using object destructuring and assigning default values, null is a legitim value, not undefined which will be replaced with default values. 

https://github.com/videsk/jwt-webauth/blob/c21afd578dff7a40bbfcd1f3fc7ed4db56614202/src/index.js#L55

So, was fixed by adding a fallback value equal to `undefined` when the value is null.

https://github.com/videsk/jwt-webauth/blob/c21afd578dff7a40bbfcd1f3fc7ed4db56614202/src/index.js#L163-L164