### PR TITLE
fix(clean): fixed key name for delete from storage

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="e8cd04de-59fb-497c-b478-dc83083e253f" name="Default Changelist" comment="chore: fix branch name on semantic release">
+    <list default="true" id="e8cd04de-59fb-497c-b478-dc83083e253f" name="Default Changelist" comment="fix(storage): return undefined not null when get tokens">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/index.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/index.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/test/auth.test.js" beforeDir="false" afterPath="$PROJECT_DIR$/test/auth.test.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -226,7 +227,8 @@
       <workItem from="1648524972884" duration="24494000" />
       <workItem from="1649105644392" duration="722000" />
       <workItem from="1649107498906" duration="40359000" />
-      <workItem from="1649344354475" duration="340000" />
+      <workItem from="1649344354475" duration="393000" />
+      <workItem from="1649357562165" duration="286000" />
     </task>
     <task id="LOCAL-00001" summary="NEW:v3.0.0">
       <created>1614872764649</created>
@@ -382,7 +384,14 @@
       <option name="project" value="LOCAL" />
       <updated>1649306376163</updated>
     </task>
-    <option name="localTasksCounter" value="23" />
+    <task id="LOCAL-00023" summary="fix(storage): return undefined not null when get tokens">
+      <created>1649344726970</created>
+      <option name="number" value="00023" />
+      <option name="presentableId" value="LOCAL-00023" />
+      <option name="project" value="LOCAL" />
+      <updated>1649344726970</updated>
+    </task>
+    <option name="localTasksCounter" value="24" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -417,7 +426,8 @@
     <MESSAGE value="fix: remove unnecessary expired conditional" />
     <MESSAGE value="chore: fix branch name" />
     <MESSAGE value="chore: fix branch name on semantic release" />
-    <option name="LAST_COMMIT_MESSAGE" value="chore: fix branch name on semantic release" />
+    <MESSAGE value="fix(storage): return undefined not null when get tokens" />
+    <option name="LAST_COMMIT_MESSAGE" value="fix(storage): return undefined not null when get tokens" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
     <SUITE FILE_PATH="coverage/front_auth_handler$test_web_auth_test_js.dat" NAME="test/web-auth.test.js Coverage Results" MODIFIED="1614825109024" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="MochaJavaScriptTestRunnerCoverage" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" />

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ class WebAuth {
      */
     clean() {
         this.debug('log', 'Cleaning store...');
-        const keys = Object.keys(this.keys);
+        const keys = Object.values(this.keys);
         keys.forEach(key => {
             window.localStorage.removeItem(key);
             window.sessionStorage.removeItem(key);

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -118,6 +118,19 @@ describe('Test WebAuth', function () {
         });
     });
 
+    it('Login, set accessToken and refreshToken, then clean storage', async function () {
+        const response = await chai.request(hostname).get('/login');
+        const { accessToken, refreshToken } = response.body;
+        const auth = new WebAuth(randomKeys());
+        auth.on('verify', () => true);
+        await auth.set(accessToken, refreshToken);
+        auth.logout();
+        chai.expect(window.localStorage.getItem(auth.keys.accessToken)).to.be.equal(undefined);
+        chai.expect(window.sessionStorage.getItem(auth.keys.accessToken)).to.be.equal(undefined);
+        chai.expect(window.localStorage.getItem(auth.keys.refreshToken)).to.be.equal(undefined);
+        chai.expect(window.sessionStorage.getItem(auth.keys.refreshToken)).to.be.equal(undefined);
+    });
+
     it('Login and set accessToken and refreshToken, then check is in sessionStorage', async function () {
         const response = await chai.request(hostname).get('/login');
         const { accessToken, refreshToken } = response.body;


### PR DESCRIPTION
Previously, the tokens on the storage were not deleted, because the code does reference the key of the storage keys options, not the values of keys. 🤦🏻 

https://github.com/videsk/jwt-webauth/blob/9ffbd10e5f96fc56fadaf0ac97d433eb700a9c99/src/index.js#L123

Now:

https://github.com/videsk/jwt-webauth/blob/0d811a44e853f4f20bdebef8f46a06d166dbe451/src/index.js#L123

🧪  Test added to verify tokens were removed
